### PR TITLE
Support Firefox

### DIFF
--- a/extension/menu.js
+++ b/extension/menu.js
@@ -8,7 +8,7 @@ chrome.runtime.onInstalled.addListener(function () {
 		onclick: opennpm
 	});
 	function opennpm(info) {
-		window.open('https://www.npmjs.com/package/' + info.selectionText, '_blank');
+		chrome.tabs.create({ url: 'https://www.npmjs.com/package/' + info.selectionText });
 	}
 	// TODO: add in npms.io option
 	// function opennpms(info) {


### PR DESCRIPTION
Changed `window.open` to `chrome.tabs.create`, which makes this extension work in Firefox (as well as Chrome, of course).

There may be more steps to get it running as an actual addon (signing, packaging, etc), but this doesn't do that.